### PR TITLE
Don't use instanceOf to check equality

### DIFF
--- a/org.jiayun.commons4e/META-INF/MANIFEST.MF
+++ b/org.jiayun.commons4e/META-INF/MANIFEST.MF
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 Bundle-Name: Commons4E
 Bundle-SymbolicName: org.jiayun.commons4e; singleton=true
-Bundle-Version: 1.1.11
+Bundle-Version: 1.1.11.f1
 Bundle-ClassPath: commons4e.jar
 Bundle-Activator: org.jiayun.commons4e.Commons4ePlugin
 Bundle-Vendor: JiaYun

--- a/org.jiayun.commons4e/src/org/jiayun/commons4e/internal/lang/generators/EqualsHashCodeGenerator.java
+++ b/org.jiayun.commons4e/src/org/jiayun/commons4e/internal/lang/generators/EqualsHashCodeGenerator.java
@@ -176,16 +176,39 @@ public final class EqualsHashCodeGenerator implements ILangGenerator {
             content.append("@Override\n");
         }
         content.append("public boolean equals(final Object other) {\n");
+        content.append("if (other == null) return false;\n");
         if (compareReferences) {
             content.append("if (this == other) return true;");
         }
-        content.append("if ( !(other instanceof ");
-        content.append(objectClass.getElementName());
-        content.append(") ) return false;\n");
-        content.append(objectClass.getElementName());
-        content.append(" castOther = (");
-        content.append(objectClass.getElementName());
-        content.append(") other;\n");
+        // by definition a.equals(b) == b.equals(a) (symmetric), using instanceOf can't assure this
+        // example: 
+		// class A {
+		//     int field1;
+		//     public A(int x) { field1 = x };
+		// }
+		// class B extends A {
+		//     int field2;
+		//     public A(int x, int y) { super(x); field2 = y };
+		// }
+        // ...
+		// A a = new A(1)
+		// B b = new B(1, 2);
+		// a.equals(b); // true
+		// b.equals(a); // false
+        //
+        // from jdk javadoc for equals:
+        // (equals) It is symmetric: for any non-null reference values x and y, x.equals(y) should return true if and only if y.equals(x) returns true. 
+
+//        content.append("if ( !(other instanceof ");
+//        content.append(objectClass.getElementName());
+//        content.append(") ) return false;\n");
+        content.append("if (!(other.getClass() == this.getClass())) return false;\n");
+
+		content.append(objectClass.getElementName());
+		content.append(" castOther = (");
+		content.append(objectClass.getElementName());
+		content.append(") other;\n");
+
         content.append("return new EqualsBuilder()");
         if (appendSuper) {
             content.append(".appendSuper(super.equals(other))");


### PR DESCRIPTION
By equals contract the equals method must be symmetric, a.equals(b) must be true only if b.equals(a) is true.
If instanceOf operator is used then a superclass can be "equals" to a subclass (superclass.equals(subclass)), but the inverse always return false, because "subclass instanceOf superclass" is always false.

BTW: Great work!
